### PR TITLE
Update CentOS Release

### DIFF
--- a/v_magine/centos.py
+++ b/v_magine/centos.py
@@ -14,7 +14,7 @@ from v_magine import utils
 
 LOG = logging
 
-DEFAULT_CENTOS_RELEASE = "7.9.2009"
+DEFAULT_CENTOS_RELEASE = "8.4.2105"
 DEFAULT_CENTOS_MIRROR = "http://mirror.centos.org/centos/%s/os/%s"
 CENTOS_VAULT_RELEASE_URL = "http://vault.centos.org/%s/os/%s"
 


### PR DESCRIPTION
Update to newer CentOS release -- installer seems it grabs a mirror from mirror.tripadvisor.com/*. Is this located somewhere else?

Currently testing.